### PR TITLE
Allow specifying port for iDRAC host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM jlesage/baseimage-gui:alpine-3.7
 
-ENV APP_NAME="iDRAC 6"
+ENV APP_NAME="iDRAC 6" \
+    IDRAC_PORT=443
 
 RUN apk add --no-cache openjdk7-jre
 

--- a/startapp.sh
+++ b/startapp.sh
@@ -11,6 +11,12 @@ if [ -z "${IDRAC_HOST}" ]; then
     exit 1
 fi
 
+if [ -z "${IDRAC_PORT}" ]; then
+    echo -e "${RED}Please set a proper idrac port with IDRAC_PORT${NC}"
+    sleep 2
+    exit 1
+fi
+
 if [ -z "${IDRAC_USER}" ]; then
     echo -e "${RED}Please set a proper idrac user with IDRAC_USER${NC}"
     sleep 2
@@ -33,7 +39,7 @@ mkdir lib
 echo "Downloading required files"
 
 if [ ! -f avctKVM.jar ]; then
-    wget https://${IDRAC_HOST}/software/avctKVM.jar --no-check-certificate
+    wget https://${IDRAC_HOST}:${IDRAC_PORT}/software/avctKVM.jar --no-check-certificate
 
     if [ ! $? -eq 0 ]; then
         echo -e "${RED}Failed to download avctKVM.jar, please check your settings${NC}"
@@ -43,7 +49,7 @@ if [ ! -f avctKVM.jar ]; then
 fi
 
 if [ ! -f lib/avctKVMIOLinux64.jar ]; then
-    wget -O lib/avctKVMIOLinux64.jar https://${IDRAC_HOST}/software/avctKVMIOLinux64.jar --no-check-certificate
+    wget -O lib/avctKVMIOLinux64.jar https://${IDRAC_HOST}:${IDRAC_PORT}/software/avctKVMIOLinux64.jar --no-check-certificate
 
     if [ ! $? -eq 0 ]; then
         echo -e "${RED}Failed to download avctKVMIOLinux64.jar, please check your settings${NC}"
@@ -53,7 +59,7 @@ if [ ! -f lib/avctKVMIOLinux64.jar ]; then
 fi
 
 if [ ! -f lib/avctVMLinux64.jar ]; then
-    wget -O lib/avctVMLinux64.jar https://${IDRAC_HOST}/software/avctVMLinux64.jar --no-check-certificate
+    wget -O lib/avctVMLinux64.jar https://${IDRAC_HOST}:${IDRAC_PORT}/software/avctVMLinux64.jar --no-check-certificate
 
     if [ ! $? -eq 0 ]; then
         echo -e "${RED}Failed to download avctVMLinux64.jar, please check your settings${NC}"


### PR DESCRIPTION
Default port is 443 and doesn't need to be defined manually.