### PR TITLE
Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
-FROM jlesage/baseimage-gui:ubuntu-16.04
+FROM jlesage/baseimage-gui:alpine-3.8-glibc
 
 ENV APP_NAME="iDRAC 6" \
-    IDRAC_PORT=443
+    IDRAC_PORT=443 \
+    HOME=/app
 
-RUN apt-get update && \
-    apt-get install -y software-properties-common wget && \
-    add-apt-repository ppa:openjdk-r/ppa && \
-    apt-get update && \
-    apt-get install -y openjdk-7-jdk && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN mkdir /app && \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+	apk update && \
+	apk add --no-cache openjdk7 wget && \
+	rm -rf /var/cache/apk/* && \
+    mkdir /app && \
     chown ${USER_ID}:${GROUP_ID} /app
 
 COPY startapp.sh /startapp.sh

--- a/startapp.sh
+++ b/startapp.sh
@@ -80,13 +80,13 @@ cd lib
 if [ ! -f lib/avctKVMIOLinux64.so ]; then
     echo "Extracting avctKVMIOLinux64"
 
-    jar -xf avctKVMIOLinux64.jar
+    /usr/lib/jvm/java-1.7-openjdk/bin/jar -xf avctKVMIOLinux64.jar
 fi
 
 if [ ! -f lib/avctVMLinux64.so ]; then
     echo "Extracting avctVMLinux64"
 
-    jar -xf avctVMLinux64.jar
+    /usr/lib/jvm/java-1.7-openjdk/bin/jar -xf avctVMLinux64.jar
 fi
 
 cd /app


### PR DESCRIPTION
Update this image for alpine.

It reduces the image size from 552MB to 193MB.