### PR TITLE
remove TLSv1 from disabledAlgorithms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && \
 RUN mkdir /app && \
     chown ${USER_ID}:${GROUP_ID} /app
 
+RUN perl -i -pe 's/^(\h*jdk\.tls\.disabledAlgorithms\h*=\h*)([\w.\h<>\n\\,]*)(TLSv1[,\n\h]\h*)/$1$2/m' /usr/lib/jvm/zulu-7-amd64/jre/lib/security/java.security
+
 COPY startapp.sh /startapp.sh
 COPY mountiso.sh /mountiso.sh
 


### PR DESCRIPTION
Without this fix I was unable to successfully use the container, getting a connection error. This simply enables TLSv1 in java.security.