### PR TITLE
fix 'Connection failed': remove all java.security restrictions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 RUN mkdir /app && \
     chown ${USER_ID}:${GROUP_ID} /app
 
-RUN perl -i -pe 's/^(\h*jdk\.tls\.disabledAlgorithms\h*=\h*)([\w.\h<>\n\\,]*)(TLSv1[,\n\h]\h*)/$1$2/m' /usr/lib/jvm/zulu-7-amd64/jre/lib/security/java.security
+RUN rm /usr/lib/jvm/zulu-7-amd64/jre/lib/security/java.security
 
 COPY startapp.sh /startapp.sh
 COPY mountiso.sh /mountiso.sh


### PR DESCRIPTION
This helps avoid the 'Connection failed' error on some iDRAC6 servers (cf. https://github.com/DomiStyle/docker-idrac6/issues/26#issuecomment-1145394137)