### PR TITLE
Add support for SOCKS5 proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN APP_ICON_URL=https://raw.githubusercontent.com/DomiStyle/docker-idrac6/maste
     install_app_icon.sh "$APP_ICON_URL"
 
 RUN apt-get update && \
-    apt-get install -y wget software-properties-common libx11-dev gcc xdotool && \
+    apt-get install -y wget curl software-properties-common libx11-dev gcc xdotool && \
     wget -nc https://cdn.azul.com/zulu/bin/zulu8.68.0.21-ca-jdk8.0.362-linux_amd64.deb && \
     apt-get install -y ./zulu8.68.0.21-ca-jdk8.0.362-linux_amd64.deb && \
     gcc -o /keycode-hack.so /keycode-hack.c -shared -s -ldl -fPIC && \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ docker run -d \
 ```
 The web interface will be available on port 5800 while the VNC server can be accessed on 5900. Startup might take a few seconds while the Java libraries are downloaded. You can add a volume on /app if you would like to cache them.
 
+## Usage (with SOCKS)
+
+```
+# Start a local port forwarding using SOCKS
+ssh -fND 4443 <remote-hostname>
+docker run -d \
+  -p 5800:5800 \
+  -p 5900:5900 \
+  -e IDRAC_HOST=idrac1.example.org \
+  -e IDRAC_USER=root \
+  -e IDRAC_PASSWORD=1234 \
+  -e SOCKS_PROXY_HOST=host.docker.internal \
+  -e SOCKS_PROXY_PORT=4443 \
+  domistyle/idrac6
+```
+
+NB: `host.docker.internal` only works on Windows and MacOS since Docker 18.03+.
+
+
 ## Configuration
 
 | Variable       | Description                                  | Required |
@@ -38,6 +57,8 @@ The web interface will be available on port 5800 while the VNC server can be acc
 |`IDRAC_PORT`| The optional port for the web interface. (443 by default) | No |
 |`IDRAC_KEYCODE_HACK`| If you have issues with keyboard input, try setting this to ``true``. See [here](https://github.com/anchor/idrac-kvm-keyboard-fix) for more infos. | No |
 |`VIRTUAL_MEDIA`| Filename of iso located within /vmedia to automount | No |
+|`SOCKS_PROXY_HOST`| The optional host for the SOCKS5 proxy. (disabled by default) | No |
+|`SOCKS_PROXY_PORT`| The optional port for the SOCKS5 proxy. (disabled by default) | No |
 
 **For advanced configuration options please take a look [here](https://github.com/jlesage/docker-baseimage-gui#environment-variables).**
 


### PR DESCRIPTION
## Context

BMCs often uses a private subnet which is not always accessible using a VPN connection.

We can start a SSH tunnel with port forwarding like this:

```
$ ssh -L 4443:<BMC_IP>:443 <remote_proxy>
```

But the image `docker-idrac6` fails because WebSockets doesn't seem supported as reported in logs:

```
webSocketsHandshake: invalid client header
```

## Proposal

Using a SOCKS5 proxy solves the issue:

```
$ ssh -fND 4443 <remote_proxy>
$ docker run -p 5800:5800 -p 5900:5900 -e SOCKS_PROXY_HOST=host.docker.internal -e SOCKS_PROXY_PORT=4443 -e IDRAC_HOST=<BMC_IP> -e IDRAC_PORT=443 -e IDRAC_USER=root -e IDRAC_PASSWORD=XXX domistyle/idrac6
```

But this implies a few changes:

- Switch to `curl` as `wget` doesn't support SOCKS.
- Use a less-secured cypher with `curl` to avoid the error `dh key too small`.