### PR TITLE
Fix 'Server disconnected (code: 1006)' error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ COPY keycode-hack.c /keycode-hack.c
 RUN APP_ICON_URL=https://raw.githubusercontent.com/DomiStyle/docker-idrac6/master/icon.png && \
     install_app_icon.sh "$APP_ICON_URL"
 
-RUN apt-get update && \
-    apt-get install -y wget software-properties-common libx11-dev gcc xdotool && \
+RUN getent group messagebus >/dev/null || addgroup --system messagebus && \
+    apt-get update && \
+    apt-get install -y wget software-properties-common libx11-dev gcc xdotool websockify && \
     wget -nc https://cdn.azul.com/zulu/bin/zulu8.68.0.21-ca-jdk8.0.362-linux_amd64.deb && \
     apt-get install -y ./zulu8.68.0.21-ca-jdk8.0.362-linux_amd64.deb && \
     gcc -o /keycode-hack.so /keycode-hack.c -shared -s -ldl -fPIC && \
@@ -27,5 +28,8 @@ RUN rm /usr/lib/jvm/zulu-8-amd64/jre/lib/security/java.security
 
 COPY startapp.sh /startapp.sh
 COPY mountiso.sh /mountiso.sh
+COPY rootfs/ /
+
+RUN chmod 755 /etc/services.d/websockify/run
 
 WORKDIR /app

--- a/rootfs/defaults/default_site.conf
+++ b/rootfs/defaults/default_site.conf
@@ -1,0 +1,41 @@
+# This is a default site configuration.
+
+map $http_upgrade $connection_upgrade {
+	default upgrade;
+	''      close;
+}
+
+server {
+	listen 5800 ssl default_server;
+	listen [::]:5800 ssl default_server;
+
+	# Path to certificate files.
+	ssl_certificate /config/certs/web-fullchain.pem;
+	ssl_certificate_key /config/certs/web-privkey.pem;
+
+	# Path of the file with Diffie-Hellman parameters for EDH ciphers.
+	ssl_dhparam /config/certs/dhparam.pem;
+
+	# Redirect HTTP traffic.
+	# https://serverfault.com/a/664936
+	error_page 497 301 =307 https://$http_host$request_uri;
+
+	root /opt/novnc;
+	index index.html;
+
+	location /websockify {
+		proxy_pass http://127.0.0.1:5901;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection $connection_upgrade;
+		proxy_read_timeout 86400;
+	}
+
+	# Access to favicons.
+	location ~* ^/(browserconfig.xml|manifest.json|safari-pinned-tab.svg|((favicon|apple-touch-icon|android-chrome|mstile)(.*)\.(ico|png)))$ {
+		root /opt/novnc/images/icons;
+		# Uncomment if access to favicon.ico generates too many logs.
+		#log_not_found off;
+		#access_log off;
+	}
+}

--- a/rootfs/etc/services.d/websockify/run
+++ b/rootfs/etc/services.d/websockify/run
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv sh
+
+set -u # Treat unset variables as an error.
+
+echo "[$(basename "$(pwd)")] starting..."
+
+exec 2>&1 /usr/bin/websockify 5901 127.0.0.1:5900
+
+# vim: set ft=sh :


### PR DESCRIPTION
This PR fixes the "Server disconnected (code: 1006)" error that occurs on some setups.

Changes included:
- Added `websockify` package.
- Added `messagebus` group setup.
- Configured `websockify` service in `rootfs`.
- Updated `Dockerfile` to include these changes.

Note: I only encountered the 1006 error, so those without it should test this first to ensure normal functionality remains intact.