### PR TITLE
Increase default display resolution to 1281x1045

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM jlesage/baseimage-gui:debian-11
 
 ENV APP_NAME="iDRAC 6"  \
     IDRAC_PORT=443      \
-    DISPLAY_WIDTH=801   \
-    DISPLAY_HEIGHT=621
+    DISPLAY_WIDTH=1281   \
+    DISPLAY_HEIGHT=1045
 
 COPY keycode-hack.c /keycode-hack.c
 


### PR DESCRIPTION
The default 801x621 resolution is quite small and requires scrolling around a lot to see the full buffer. This bumps it to 1281x1045 for a better out-of-the-box experience.